### PR TITLE
Correct part number for Murata 1uF capacitor

### DIFF
--- a/CPL for Production/Capacitors.yaml
+++ b/CPL for Production/Capacitors.yaml
@@ -710,7 +710,7 @@ rows:
   - uid: 915b5852b5104e9c
     ppid: "196909"
     manufacturer: Murata
-    mpn: GRM188R71E224KA88D
+    mpn: GRM188R71E105KA12D
     externalurl: ""
     imageurl: http://sigma.octopart.com/21366167/image/Murata-GRM1885C1H102JA01D.jpg
     footprinturl: http://www.snapeda.com/parts/GRM155R60J105KE19D/Murata/view-part/


### PR DESCRIPTION
The existing MPN is for a 0.22uF part. This is the 1uF part from that series. 